### PR TITLE
feat: Improve sync API

### DIFF
--- a/diffact-slick/src/main/scala/diffact/slick/DifferExtension.scala
+++ b/diffact-slick/src/main/scala/diffact/slick/DifferExtension.scala
@@ -4,7 +4,7 @@ import cats.data.NonEmptyList
 import diffact.Difference
 
 extension [A](diffs: Seq[Difference[A]]) {
-  def groupByType: (
+  private[slick] def groupByType: (
     Seq[Difference.Added[A]],
     Seq[Difference.Removed[A]],
     Seq[Difference.Changed[A]],
@@ -16,7 +16,7 @@ extension [A](diffs: Seq[Difference[A]]) {
     }
   }
 
-  def groupNelByType: (
+  private[slick] def groupNelByType: (
     Option[NonEmptyList[Difference.Added[A]]],
     Option[NonEmptyList[Difference.Removed[A]]],
     Option[NonEmptyList[Difference.Changed[A]]],

--- a/diffact-slick/src/main/scala/diffact/slick/DifferSlickComponent.scala
+++ b/diffact-slick/src/main/scala/diffact/slick/DifferSlickComponent.scala
@@ -62,8 +62,8 @@ trait DifferSlickComponent { self: _root_.slick.jdbc.JdbcProfile =>
         val (maybeAdded, maybeRemoved, maybeChanged) = diffs.groupNelByType
 
         for {
-          r1 <- maybeAdded.map(add).getOrElse(empty)
-          r2 <- maybeRemoved.map(remove).getOrElse(empty)
+          r1 <- maybeRemoved.map(remove).getOrElse(empty)
+          r2 <- maybeAdded.map(add).getOrElse(empty)
           r3 <- maybeChanged.map(change).getOrElse(empty)
         } yield {
           r1 |+| r2 |+| r3
@@ -81,6 +81,28 @@ trait DifferSlickComponent { self: _root_.slick.jdbc.JdbcProfile =>
           change = diffs => change(diffs).void,
         )
       }
+
+      def syncEach[R: Monoid](
+        add: Difference.Added[A] => DBIOAction[R, NoStream, Effect.Write],
+        remove: Difference.Removed[A] => DBIOAction[R, NoStream, Effect.Write],
+        change: Difference.Changed[A] => DBIOAction[R, NoStream, Effect.Write],
+      )(using ExecutionContext): DBIOAction[R, NoStream, Effect.Write] =
+        sync(
+          add = nel => DBIO.sequence(nel.toList.map(add)).map(_.combineAll),
+          remove = nel => DBIO.sequence(nel.toList.map(remove)).map(_.combineAll),
+          change = nel => DBIO.sequence(nel.toList.map(change)).map(_.combineAll),
+        )
+
+      def syncEachDiscard(
+        add: Difference.Added[A] => DBIOAction[Any, NoStream, Effect.Write],
+        remove: Difference.Removed[A] => DBIOAction[Any, NoStream, Effect.Write],
+        change: Difference.Changed[A] => DBIOAction[Any, NoStream, Effect.Write],
+      )(using ExecutionContext): DBIOAction[Unit, NoStream, Effect.Write] =
+        syncEach(
+          add = d => add(d).void,
+          remove = d => remove(d).void,
+          change = d => change(d).void,
+        )
     }
 
   }


### PR DESCRIPTION
## Summary

- Change `Seq[Difference[A]]#sync` execution order from add→remove→change to **remove→add→change** for FK constraint safety
- Add `syncEach` / `syncEachDiscard` for single-element handlers (eliminates `DBIO.sequence(nel.toList.map(...))` boilerplate)
- Restrict `groupByType` / `groupNelByType` to `private[slick]`
