### PR TITLE
refactor: move useReadableConsoleGit to git.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 ThisBuild / scalaVersion := "3.8.1"
-useReadableConsoleGit
 ThisBuild / organization := "dev.hshn"
 ThisBuild / homepage     := Some(url("https://github.com/hshn/diffact"))
 ThisBuild / licenses     := List("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0"))

--- a/git.sbt
+++ b/git.sbt
@@ -1,0 +1,1 @@
+useReadableConsoleGit


### PR DESCRIPTION
## Summary
- Move `useReadableConsoleGit` from `build.sbt` to dedicated `git.sbt` to separate plugin-specific config from project metadata
