### PR TITLE
ci: add scalafmt check to CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,18 @@ on:
   pull_request:
 
 jobs:
+  scalafmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
+      - run: sbt scalafmtCheckAll
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -23,7 +35,7 @@ jobs:
 
   test-all:
     if: always()
-    needs: [test]
+    needs: [scalafmt, test]
     runs-on: ubuntu-latest
     steps:
-      - run: if [[ "${{ needs.test.result }}" != "success" ]]; then exit 1; fi
+      - run: if [[ "${{ needs.scalafmt.result }}" != "success" || "${{ needs.test.result }}" != "success" ]]; then exit 1; fi


### PR DESCRIPTION
## Summary
- Add `scalafmt` job running `sbt scalafmtCheckAll` to enforce formatting in CI
- Include `scalafmt` in `test-all` gate job to block merges on format violations

Closes #18