### PR TITLE
refactor: make groupByType type-safe and move to diffact-core

### DIFF
--- a/diffact-core/src/main/scala/diffact/GroupedDifferences.scala
+++ b/diffact-core/src/main/scala/diffact/GroupedDifferences.scala
@@ -1,0 +1,23 @@
+package diffact
+
+case class GroupedDifferences[A](
+  added: Seq[Difference.Added[A]],
+  removed: Seq[Difference.Removed[A]],
+  changed: Seq[Difference.Changed[A]],
+)
+
+object GroupedDifferences {
+  extension [A](diffs: Seq[Difference[A]]) {
+    def groupByType: GroupedDifferences[A] = {
+      val added   = Seq.newBuilder[Difference.Added[A]]
+      val removed = Seq.newBuilder[Difference.Removed[A]]
+      val changed = Seq.newBuilder[Difference.Changed[A]]
+      diffs.foreach {
+        case diff: Difference.Added[A]   => added += diff
+        case diff: Difference.Removed[A] => removed += diff
+        case diff: Difference.Changed[A] => changed += diff
+      }
+      GroupedDifferences(added.result(), removed.result(), changed.result())
+    }
+  }
+}

--- a/diffact-core/src/test/scala/diffact/GroupedDifferencesSpec.scala
+++ b/diffact-core/src/test/scala/diffact/GroupedDifferencesSpec.scala
@@ -1,0 +1,36 @@
+package diffact
+
+import diffact.GroupedDifferences.*
+import zio.Scope
+import zio.test.*
+
+object GroupedDifferencesSpec extends ZIOSpecDefault {
+  override def spec: Spec[TestEnvironment & Scope, Any] = suiteAll("GroupedDifferences") {
+    suiteAll("groupByType") {
+      test("groups differences by type") {
+        val diffs: Seq[Difference[Int]] = Seq(
+          Difference.Added(1),
+          Difference.Removed(2),
+          Difference.Changed(3, 4),
+          Difference.Added(5),
+        )
+        assertTrue(
+          diffs.groupByType == GroupedDifferences(
+            added = Seq(Difference.Added(1), Difference.Added(5)),
+            removed = Seq(Difference.Removed(2)),
+            changed = Seq(Difference.Changed(3, 4)),
+          )
+        )
+      }
+      test("returns empty seqs for empty input") {
+        assertTrue(
+          Seq.empty[Difference[Int]].groupByType == GroupedDifferences(
+            added = Seq.empty,
+            removed = Seq.empty,
+            changed = Seq.empty,
+          )
+        )
+      }
+    }
+  }
+}

--- a/diffact-slick/src/main/scala/diffact/slick/DifferExtension.scala
+++ b/diffact-slick/src/main/scala/diffact/slick/DifferExtension.scala
@@ -2,26 +2,19 @@ package diffact.slick
 
 import cats.data.NonEmptyList
 import diffact.Difference
+import diffact.GroupedDifferences.*
 
 extension [A](diffs: Seq[Difference[A]]) {
-  private[slick] def groupByType: (
-    Seq[Difference.Added[A]],
-    Seq[Difference.Removed[A]],
-    Seq[Difference.Changed[A]],
-  ) = {
-    diffs.foldLeft((Seq.empty[Difference.Added[A]], Seq.empty[Difference.Removed[A]], Seq.empty[Difference.Changed[A]])) {
-      case ((added, removed, changed), diff: Difference.Added[A])   => (added :+ diff, removed, changed)
-      case ((added, removed, changed), diff: Difference.Removed[A]) => (added, removed :+ diff, changed)
-      case ((added, removed, changed), diff: Difference.Changed[A]) => (added, removed, changed :+ diff)
-    }
-  }
-
   private[slick] def groupNelByType: (
     Option[NonEmptyList[Difference.Added[A]]],
     Option[NonEmptyList[Difference.Removed[A]]],
     Option[NonEmptyList[Difference.Changed[A]]],
   ) = {
-    val (added, removed, changed) = groupByType
-    (NonEmptyList.fromList(added.toList), NonEmptyList.fromList(removed.toList), NonEmptyList.fromList(changed.toList))
+    val grouped = diffs.groupByType
+    (
+      NonEmptyList.fromList(grouped.added.toList),
+      NonEmptyList.fromList(grouped.removed.toList),
+      NonEmptyList.fromList(grouped.changed.toList),
+    )
   }
 }

--- a/diffact-slick/src/test/scala/diffact/slick/DifferExtensionSpec.scala
+++ b/diffact-slick/src/test/scala/diffact/slick/DifferExtensionSpec.scala
@@ -7,30 +7,6 @@ import zio.test.*
 
 object DifferExtensionSpec extends ZIOSpecDefault {
   override def spec: Spec[TestEnvironment & Scope, Any] = suiteAll("DifferExtension") {
-    suiteAll("groupByType") {
-      test("groups differences by type") {
-        val diffs: Seq[Difference[Int]] = Seq(
-          Difference.Added(1),
-          Difference.Removed(2),
-          Difference.Changed(3, 4),
-          Difference.Added(5),
-        )
-        val (added, removed, changed) = diffs.groupByType
-        assertTrue(
-          added == Seq(Difference.Added(1), Difference.Added(5)),
-          removed == Seq(Difference.Removed(2)),
-          changed == Seq(Difference.Changed(3, 4)),
-        )
-      }
-      test("returns empty seqs for empty input") {
-        val (added, removed, changed) = Seq.empty[Difference[Int]].groupByType
-        assertTrue(
-          added.isEmpty,
-          removed.isEmpty,
-          changed.isEmpty,
-        )
-      }
-    }
     suiteAll("groupNelByType") {
       test("groups differences as NonEmptyList options") {
         val diffs: Seq[Difference[Int]] = Seq(


### PR DESCRIPTION
## Summary
- Introduce `GroupedDifferences[A]` case class with named fields (`added`, `removed`, `changed`) to replace error-prone tuple return type
- Move `groupByType` from `private[slick]` in `diffact-slick` to public API in `diffact-core`
- Improve `groupByType` performance from O(n²) to O(n) using `Seq.newBuilder`

Closes #19