### PR TITLE
feat: add generic fold method to Difference

### DIFF
--- a/diffact-core/src/main/scala/diffact/Difference.scala
+++ b/diffact-core/src/main/scala/diffact/Difference.scala
@@ -1,6 +1,16 @@
 package diffact
 
-sealed trait Difference[+A] extends Product with Serializable
+sealed trait Difference[+A] extends Product with Serializable {
+  def fold[B](
+    added: A => B,
+    removed: A => B,
+    changed: (A, A) => B,
+  ): B = this match {
+    case Difference.Added(value)                => added(value)
+    case Difference.Removed(value)              => removed(value)
+    case Difference.Changed(oldValue, newValue) => changed(oldValue, newValue)
+  }
+}
 object Difference {
   case class Added[+A](value: A)                   extends Difference[A]
   case class Removed[+A](value: A)                 extends Difference[A]

--- a/diffact-core/src/test/scala/diffact/DifferenceFoldSpec.scala
+++ b/diffact-core/src/test/scala/diffact/DifferenceFoldSpec.scala
@@ -1,0 +1,39 @@
+package diffact
+
+import zio.Scope
+import zio.test.Spec
+import zio.test.TestEnvironment
+import zio.test.ZIOSpecDefault
+import zio.test.assertTrue
+
+object DifferenceFoldSpec extends ZIOSpecDefault {
+  override def spec: Spec[TestEnvironment & Scope, Any] = suiteAll("Difference#fold") {
+    test("dispatches Added to added handler") {
+      val diff: Difference[Int] = Difference.Added(1)
+      val result                = diff.fold(
+        added = v => s"added:$v",
+        removed = v => s"removed:$v",
+        changed = (o, n) => s"changed:$o->$n",
+      )
+      assertTrue(result == "added:1")
+    }
+    test("dispatches Removed to removed handler") {
+      val diff: Difference[Int] = Difference.Removed(2)
+      val result                = diff.fold(
+        added = v => s"added:$v",
+        removed = v => s"removed:$v",
+        changed = (o, n) => s"changed:$o->$n",
+      )
+      assertTrue(result == "removed:2")
+    }
+    test("dispatches Changed to changed handler") {
+      val diff: Difference[Int] = Difference.Changed(3, 4)
+      val result                = diff.fold(
+        added = v => s"added:$v",
+        removed = v => s"removed:$v",
+        changed = (o, n) => s"changed:$o->$n",
+      )
+      assertTrue(result == "changed:3->4")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `fold` method directly on `Difference[A]` sealed trait as a general-purpose combinator
- Enables pattern matching over `Added`/`Removed`/`Changed` without framework dependencies

Closes #21