### PR TITLE
feat: preserve key information in MapDiffer diff results

### DIFF
--- a/diffact-core/src/main/scala/diffact/MapDiffer.scala
+++ b/diffact-core/src/main/scala/diffact/MapDiffer.scala
@@ -1,17 +1,17 @@
 package diffact
 
 case class MapDiffer[K, V](differ: ValueDiffer[V]) extends Differ[Map[K, V]] {
-  override type DiffResult = Seq[Difference[V]]
+  override type DiffResult = Seq[(K, Difference[V])]
 
   override def diff(oldValue: Map[K, V], newValue: Map[K, V]): DiffResult = {
-    val added   = (newValue -- oldValue.keys).values.toSeq.map(Difference.Added(_))
-    val removed = (oldValue -- newValue.keys).values.toSeq.map(Difference.Removed(_))
+    val added   = (newValue -- oldValue.keys).toSeq.map((k, v) => k -> Difference.Added(v))
+    val removed = (oldValue -- newValue.keys).toSeq.map((k, v) => k -> Difference.Removed(v))
     val changed = (newValue.keySet & oldValue.keySet).toSeq
-      .flatMap(key => differ.diff(oldValue = oldValue(key), newValue = newValue(key)))
+      .flatMap(key => differ.diff(oldValue = oldValue(key), newValue = newValue(key)).map(d => key -> d))
     added ++ removed ++ changed
   }
 
-  override def added(newValue: Map[K, V]): Seq[Difference[V]]   = newValue.values.toSeq.map(Difference.Added(_))
-  override def removed(oldValue: Map[K, V]): Seq[Difference[V]] = oldValue.values.toSeq.map(Difference.Removed(_))
-  override def none: Seq[Difference[V]]                         = Nil
+  override def added(newValue: Map[K, V]): Seq[(K, Difference[V])]   = newValue.toSeq.map((k, v) => k -> Difference.Added(v))
+  override def removed(oldValue: Map[K, V]): Seq[(K, Difference[V])] = oldValue.toSeq.map((k, v) => k -> Difference.Removed(v))
+  override def none: Seq[(K, Difference[V])]                         = Nil
 }

--- a/diffact-core/src/test/scala/diffact/MapDifferSpec.scala
+++ b/diffact-core/src/test/scala/diffact/MapDifferSpec.scala
@@ -12,30 +12,30 @@ object MapDifferSpec extends ZIOSpecDefault {
       test("detects added entries") {
         assertTrue(
           Differ.diff(Map("a" -> 1, "b" -> 2)).from(Map("a" -> 1)).toSet == Set(
-            Difference.Added(2)
+            "b" -> Difference.Added(2)
           )
         )
       }
       test("detects removed entries") {
         assertTrue(
           Differ.diff(Map("a" -> 1)).from(Map("a" -> 1, "b" -> 2)).toSet == Set(
-            Difference.Removed(2)
+            "b" -> Difference.Removed(2)
           )
         )
       }
       test("detects changed values") {
         assertTrue(
           Differ.diff(Map("a" -> 2)).from(Map("a" -> 1)).toSet == Set(
-            Difference.Changed(oldValue = 1, newValue = 2)
+            "a" -> Difference.Changed(oldValue = 1, newValue = 2)
           )
         )
       }
       test("detects additions, removals, and changes simultaneously") {
         assertTrue(
           Differ.diff(Map("a" -> 10, "c" -> 3)).from(Map("a" -> 1, "b" -> 2)).toSet == Set(
-            Difference.Added(3),
-            Difference.Removed(2),
-            Difference.Changed(oldValue = 1, newValue = 10),
+            "c" -> Difference.Added(3),
+            "b" -> Difference.Removed(2),
+            "a" -> Difference.Changed(oldValue = 1, newValue = 10),
           )
         )
       }
@@ -54,14 +54,14 @@ object MapDifferSpec extends ZIOSpecDefault {
       test("added") {
         val differ = summon[MapDiffer[String, Int]]
         assertTrue(
-          differ.added(Map("a" -> 1, "b" -> 2)).toSet == Set(Difference.Added(1), Difference.Added(2)),
+          differ.added(Map("a" -> 1, "b" -> 2)).toSet == Set("a" -> Difference.Added(1), "b" -> Difference.Added(2)),
           differ.added(Map.empty[String, Int]).isEmpty,
         )
       }
       test("removed") {
         val differ = summon[MapDiffer[String, Int]]
         assertTrue(
-          differ.removed(Map("a" -> 1, "b" -> 2)).toSet == Set(Difference.Removed(1), Difference.Removed(2)),
+          differ.removed(Map("a" -> 1, "b" -> 2)).toSet == Set("a" -> Difference.Removed(1), "b" -> Difference.Removed(2)),
           differ.removed(Map.empty[String, Int]).isEmpty,
         )
       }


### PR DESCRIPTION
## Summary
- Change `MapDiffer.DiffResult` from `Seq[Difference[V]]` to `Seq[(K, Difference[V])]` so callers know which key was added, removed, or changed
- Update all `MapDifferSpec` assertions to include keys in expected results

Closes #16